### PR TITLE
Enforce https in the SaferMatcher url

### DIFF
--- a/perception/tools.py
+++ b/perception/tools.py
@@ -5,6 +5,7 @@ import json
 import base64
 import typing
 import warnings
+import urllib.parse
 import urllib.request
 
 try:
@@ -227,6 +228,10 @@ class SaferMatcher:
                 raise ValueError(
                     'You must provide either the url or the SAFER_MATCHING_SERVICE_URL env var.'
                 )
+        if urllib.parse.urlparse(url).scheme != 'https' and not os.environ.get(
+                'SAFER_MATCHING_SERVICE_DEV_ALLOW_HTTP'):
+            raise ValueError(
+                'You must provide an url that begins with `https://`.')
         self.api_key = api_key
         self.url = url
         if hasher is None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,6 +2,8 @@ import tempfile
 import shutil
 import os
 
+import pytest
+
 from perception import hashers, tools, testing
 
 
@@ -21,3 +23,20 @@ def test_deduplicate():
     assert ((file1 == duplicate) and
             (file2 == original)) or ((file1 == original) and
                                      (file2 == duplicate))
+
+
+def test_api_is_over_https():
+    matcher_https = tools.SaferMatcher(
+        api_key='foo', url='https://www.example.com/')
+    assert matcher_https
+
+    if 'SAFER_MATCHING_SERVICE_DEV_ALLOW_HTTP' in os.environ:
+        del os.environ['SAFER_MATCHING_SERVICE_DEV_ALLOW_HTTP']
+    with pytest.raises(ValueError):
+        matcher_http = tools.SaferMatcher(
+            api_key='foo', url='http://www.example.com/')
+
+    os.environ['SAFER_MATCHING_SERVICE_DEV_ALLOW_HTTP'] = '1'
+    matcher_http_with_escape_hatch = tools.SaferMatcher(
+        api_key='foo', url='http://www.example.com/')
+    assert matcher_http_with_escape_hatch


### PR DESCRIPTION
Closes https://github.com/thorn-oss/perception/issues/1

I included an escape hatch in case you do local development for your backend and want to test your client against e.g. localhost. Comments welcome if you prefer something else!