### PR TITLE
Require pdqhash for users of the package, not just dev

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,3 +12,4 @@ faiss-cpu
 aiohttp
 python-json-logger
 networkit
+pdqhash


### PR DESCRIPTION
Currently pdqhash is only installed in the dev-packages section of the Pipfile, and is not pulled in when users install from pip (which is presumably what's causing #27).  