### PR TITLE
Scene detection was broken due to accessing a key that didn't exist

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week.
+      interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week.
-      interval: "weekly"

--- a/perception/hashers/video/scenes.py
+++ b/perception/hashers/video/scenes.py
@@ -136,7 +136,7 @@ class SimpleSceneDetection(VideoHasher):
                 (
                     self.interscene_threshold is None
                     or not state["scenes"]
-                    or self.compute_distance(state["scenes"][-1][0], subhash)
+                    or self.compute_distance(state["scenes"][-1]['hash'], subhash)
                     > self.interscene_threshold
                 )
             )


### PR DESCRIPTION
It looks like the format changed; I've updated it using the change in this PR and it now works for me.