### PR TITLE
Modernize the Python Syntax for 3.10 (#168)

### DIFF
--- a/perception/__init__.py
+++ b/perception/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "0.0.0"
+from importlib import metadata
+
+__version__ = metadata.version("perception")

--- a/perception/benchmarking/common.py
+++ b/perception/benchmarking/common.py
@@ -3,12 +3,10 @@ import logging
 import os
 import shutil
 import tempfile
-import typing
 import uuid
 import warnings
 import zipfile
 from abc import ABC
-from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -101,7 +99,7 @@ def compute_threshold_precision_recall(pos, neg, precision_threshold=99.9):
 
 class Filterable(ABC):
     _df: pd.DataFrame
-    expected_columns: typing.List
+    expected_columns: list
 
     def __init__(self, df):
         assert sorted(df.columns) == sorted(
@@ -135,7 +133,7 @@ class Saveable(Filterable):
     def load(
         cls,
         path_to_zip_or_directory: str,
-        storage_dir: Optional[str] = None,
+        storage_dir: str | None = None,
         verify_md5=True,
     ):
         """Load a dataset from a ZIP file or directory.
@@ -311,7 +309,7 @@ class BenchmarkHashes(Filterable):
 
     def __init__(self, df: pd.DataFrame):
         super().__init__(df)
-        self._metrics: Optional[pd.DataFrame] = None
+        self._metrics: pd.DataFrame | None = None
 
     def __add__(self, other):
         return BenchmarkHashes(df=pd.concat([self._df, other._df]).drop_duplicates())
@@ -327,7 +325,7 @@ class BenchmarkHashes(Filterable):
         self._df.to_csv(filepath, index=False)
 
     def compute_metrics(
-        self, custom_distance_metrics: Optional[dict] = None
+        self, custom_distance_metrics: dict | None = None
     ) -> pd.DataFrame:
         if self._metrics is not None:
             return self._metrics
@@ -610,7 +608,7 @@ class BenchmarkDataset(Saveable):
     expected_columns = ["filepath", "category"]
 
     @classmethod
-    def from_tuples(cls, files: typing.List[typing.Tuple[str, str]]):
+    def from_tuples(cls, files: list[tuple[str, str]]):
         """Build dataset from a set of files.
 
         Args:

--- a/perception/benchmarking/image.py
+++ b/perception/benchmarking/image.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import typing
 import uuid
 import warnings
 
@@ -19,7 +18,7 @@ log = logging.getLogger(__name__)
 
 class BenchmarkImageTransforms(BenchmarkTransforms):
     def compute_hashes(
-        self, hashers: typing.Dict[str, ImageHasher], max_workers: int = 5
+        self, hashers: dict[str, ImageHasher], max_workers: int = 5
     ) -> BenchmarkHashes:
         """Compute hashes for a series of files given some set of hashers.
 
@@ -86,7 +85,7 @@ class BenchmarkImageTransforms(BenchmarkTransforms):
 class BenchmarkImageDataset(BenchmarkDataset):
     def deduplicate(
         self, hasher: ImageHasher, threshold=0.001, isometric=False
-    ) -> typing.Tuple["BenchmarkImageDataset", typing.Set[typing.Tuple[str, str]]]:
+    ) -> tuple["BenchmarkImageDataset", set[tuple[str, str]]]:
         """Remove duplicate files from dataset.
 
         Args:
@@ -99,7 +98,7 @@ class BenchmarkImageDataset(BenchmarkDataset):
             A list where each entry is a list of files that are
             duplicates of each other. We keep only the last entry.
         """
-        pairs: typing.Set[typing.Tuple[str, str]] = set()
+        pairs: set[tuple[str, str]] = set()
         for _, group in tqdm(
             self._df.groupby(["category"]), desc="Deduplicating categories."
         ):
@@ -120,7 +119,7 @@ class BenchmarkImageDataset(BenchmarkDataset):
 
     def transform(
         self,
-        transforms: typing.Dict[str, imgaug.augmenters.meta.Augmenter],
+        transforms: dict[str, imgaug.augmenters.meta.Augmenter],
         storage_dir: str,
         errors: str = "raise",
     ) -> BenchmarkImageTransforms:

--- a/perception/benchmarking/video.py
+++ b/perception/benchmarking/video.py
@@ -68,7 +68,7 @@ def _process_row(row, hashers, framerates):
 class BenchmarkVideoDataset(BenchmarkDataset):
     def transform(
         self,
-        transforms: typing.Dict[str, typing.Callable],
+        transforms: dict[str, typing.Callable],
         storage_dir: str,
         errors: str = "raise",
     ):
@@ -171,7 +171,7 @@ class BenchmarkVideoTransforms(BenchmarkTransforms):
     ]
 
     def compute_hashes(
-        self, hashers: typing.Dict[str, VideoHasher], max_workers: int = 5
+        self, hashers: dict[str, VideoHasher], max_workers: int = 5
     ) -> BenchmarkHashes:
         """Compute hashes for a series of files given some set of hashers.
 

--- a/perception/benchmarking/video_transforms.py
+++ b/perception/benchmarking/video_transforms.py
@@ -1,6 +1,4 @@
 import os
-import typing
-from typing import Optional
 
 import cv2
 import ffmpeg
@@ -29,12 +27,12 @@ def sanitize_output_filepath(input_filepath, output_filepath, output_ext=None):
 
 
 def get_simple_transform(
-    width: typing.Union[str, int] = -1,
-    height: typing.Union[str, int] = -1,
-    pad: Optional[str] = None,
-    codec: Optional[str] = None,
-    clip_pct: Optional[typing.Tuple[float, float]] = None,
-    clip_s: Optional[typing.Tuple[float, float]] = None,
+    width: str | int = -1,
+    height: str | int = -1,
+    pad: str | None = None,
+    codec: str | None = None,
+    clip_pct: tuple[float, float] | None = None,
+    clip_s: tuple[float, float] | None = None,
     sar=None,
     fps=None,
     output_ext=None,

--- a/perception/experimental/ann/index.py
+++ b/perception/experimental/ann/index.py
@@ -1,7 +1,6 @@
 import time
 import typing
 import warnings
-from typing import Optional
 
 import faiss
 import numpy as np
@@ -10,11 +9,15 @@ import typing_extensions
 
 import perception.hashers.tools as pht
 
-QueryInput = typing_extensions.TypedDict("QueryInput", {"id": str, "hash": str})
 
-QueryMatch = typing_extensions.TypedDict(
-    "QueryMatch", {"id": typing.Any, "matches": typing.List[dict]}
-)
+class QueryInput(typing_extensions.TypedDict):
+    id: str
+    hash: str
+
+
+class QueryMatch(typing_extensions.TypedDict):
+    id: typing.Any
+    matches: list[dict]
 
 
 class TuningFailure(Exception):
@@ -260,7 +263,7 @@ class ApproximateNearestNeighbors:
             s, hash_format=hash_format, dtype=self.dtype, hash_length=self.hash_length
         )
 
-    def vector_to_string(self, vector, hash_format="base64") -> typing.Optional[str]:
+    def vector_to_string(self, vector, hash_format="base64") -> str | None:
         """Convert a vector back to string
 
         Args:
@@ -272,9 +275,9 @@ class ApproximateNearestNeighbors:
 
     def search(
         self,
-        queries: typing.List[QueryInput],
-        threshold: Optional[int] = None,
-        threshold_func: Optional[typing.Callable[[np.ndarray], np.ndarray]] = None,
+        queries: list[QueryInput],
+        threshold: int | None = None,
+        threshold_func: typing.Callable[[np.ndarray], np.ndarray] | None = None,
         hash_format="base64",
         k=1,
     ):
@@ -318,7 +321,7 @@ class ApproximateNearestNeighbors:
             if not self.metadata_columns
             else self.query_by_id(ids=np.unique(indices[distances < thresholds]))
         )
-        matches: typing.List[QueryMatch] = []
+        matches: list[QueryMatch] = []
         for match_distances, match_ids, q, q_threshold in zip(
             distances, indices, queries, thresholds
         ):

--- a/perception/experimental/ann/serve.py
+++ b/perception/experimental/ann/serve.py
@@ -3,7 +3,6 @@ import functools
 import json
 import logging
 import typing
-from typing import Optional
 
 import aiohttp.web
 import numpy as np
@@ -96,8 +95,8 @@ def get_logger(name, log_level):
 
 async def serve(
     index: ApproximateNearestNeighbors,
-    default_threshold: Optional[int] = None,
-    default_threshold_func: Optional[typing.Callable[[np.ndarray], np.ndarray]] = None,
+    default_threshold: int | None = None,
+    default_threshold_func: typing.Callable[[np.ndarray], np.ndarray] | None = None,
     default_k: int = 1,
     concurrency: int = 2,
     log_level=logging.INFO,

--- a/perception/experimental/approximate_deduplication.py
+++ b/perception/experimental/approximate_deduplication.py
@@ -2,7 +2,6 @@ import logging
 import math
 import os.path as op
 import typing
-from typing import Optional
 
 import faiss
 import networkit as nk
@@ -17,9 +16,10 @@ DEFAULT_PCT_PROBE = 0
 # For faiss training on datasets larger than 50,000 vectors, we take a random sub-sample.
 TRAIN_LARGE_SIZE: int = 50_000
 
-ClusterAssignment = typing_extensions.TypedDict(
-    "ClusterAssignment", {"cluster": int, "id": typing.Any}
-)
+
+class ClusterAssignment(typing_extensions.TypedDict):
+    cluster: int
+    id: typing.Any
 
 
 def build_index(
@@ -90,7 +90,7 @@ def compute_euclidean_pairwise_duplicates_approx(
     y_counts=None,
     pct_probe=0.1,
     use_gpu: bool = True,
-    faiss_cache_path: Optional[str] = None,
+    faiss_cache_path: str | None = None,
     show_progress: bool = False,
 ):
     """Provides the same result as perception.extensions.compute_pairwise_duplicates_simple
@@ -199,12 +199,12 @@ def compute_euclidean_pairwise_duplicates_approx(
 
 def pairs_to_clusters(
     ids: typing.Iterable[str],
-    pairs: typing.Iterable[typing.Tuple[str, str]],
+    pairs: typing.Iterable[tuple[str, str]],
     strictness: typing_extensions.Literal[
         "clique", "community", "component"
     ] = "clique",
     max_clique_batch_size: int = 1000,
-) -> typing.List[ClusterAssignment]:
+) -> list[ClusterAssignment]:
     """Given a list of pairs of matching files, compute sets
     of cliques where all files in a clique are connected.
     Args:
@@ -232,7 +232,7 @@ def pairs_to_clusters(
     for node_pair in node_pairs:
         graph.addEdge(node_pair[0], node_pair[1])
 
-    assignments: typing.List[ClusterAssignment] = []
+    assignments: list[ClusterAssignment] = []
     cluster_index = 0
     cc_query = nk.components.ConnectedComponents(graph)
     cc_query.run()

--- a/perception/experimental/debug.py
+++ b/perception/experimental/debug.py
@@ -1,6 +1,5 @@
 import logging
 import random
-from typing import Optional
 
 import cv2
 import numpy as np
@@ -18,7 +17,7 @@ def vizualize_pair(
     features_2,
     ratio: float,
     match_metadata=None,
-    local_path_col: Optional[str] = None,
+    local_path_col: str | None = None,
     sanitized: bool = False,
     include_all_points=False,
     circle_size=KEYPOINT_SIZE,

--- a/perception/hashers/hasher.py
+++ b/perception/hashers/hasher.py
@@ -3,7 +3,6 @@ import typing
 import warnings
 from abc import ABC, abstractmethod
 from logging import warning
-from typing import Optional
 
 import numpy as np
 import scipy.spatial
@@ -50,7 +49,7 @@ class Hasher(ABC):
 
     def vector_to_string(
         self, vector: np.ndarray, hash_format: str = "base64"
-    ) -> typing.Optional[str]:
+    ) -> str | None:
         """Convert vector to hash string.
 
         Args:
@@ -61,8 +60,8 @@ class Hasher(ABC):
 
     def compute_distance(
         self,
-        hash1: typing.Union[np.ndarray, str],
-        hash2: typing.Union[np.ndarray, str],
+        hash1: np.ndarray | str,
+        hash2: np.ndarray | str,
         hash_format="base64",
     ):
         """Compute the distance between two hashes.
@@ -110,9 +109,9 @@ class Hasher(ABC):
     @typing.no_type_check
     def compute_parallel(
         self,
-        filepaths: typing.List[str],
-        progress: Optional["tqdm.tqdm"] = None,
-        progress_desc: Optional[str] = None,
+        filepaths: list[str],
+        progress: tqdm.tqdm | None = None,
+        progress_desc: str | None = None,
         max_workers: int = 5,
         isometric: bool = False,
     ):
@@ -231,9 +230,7 @@ class ImageHasher(Hasher):
 
     def compute(
         self, image: tools.ImageInputType, hash_format="base64"
-    ) -> typing.Union[
-        np.ndarray, typing.Optional[str], typing.List[typing.Optional[str]]
-    ]:
+    ) -> np.ndarray | str | None | list[str | None]:
         """Compute a hash from an image.
 
         Args:
@@ -259,10 +256,8 @@ class ImageHasher(Hasher):
 
     def compute_with_quality(
         self, image: tools.ImageInputType, hash_format="base64"
-    ) -> typing.Tuple[
-        typing.Union[
-            np.ndarray, typing.Optional[str], typing.List[typing.Optional[str]]
-        ],
+    ) -> tuple[
+        (np.ndarray | str | None | list[str | None]),
         int,
     ]:
         """Compute hash and hash quality from image.
@@ -287,7 +282,7 @@ class ImageHasher(Hasher):
             )
         return (self.vector_to_string(vector, hash_format=hash_format), quality)
 
-    def _compute_with_quality(self, image: np.ndarray) -> typing.Tuple[np.ndarray, int]:
+    def _compute_with_quality(self, image: np.ndarray) -> tuple[np.ndarray, int]:
         return self._compute(image), tools.compute_quality(image)
 
 
@@ -300,9 +295,9 @@ class VideoHasher(Hasher):
     def process_frame(
         self,
         frame: np.ndarray,
-        frame_index: typing.Optional[int],
-        frame_timestamp: typing.Optional[float],
-        state: Optional[dict] = None,
+        frame_index: int | None,
+        frame_timestamp: float | None,
+        state: dict | None = None,
     ) -> dict:
         """Called for each frame in the video. For all
         but the first frame, a state is provided recording the state from
@@ -327,7 +322,7 @@ class VideoHasher(Hasher):
     def compute_with_timestamps(
         self, filepath, errors="raise", hash_format="base64", **kwargs
     ):
-        scenes: typing.List[dict] = []
+        scenes: list[dict] = []
         hashes = self.compute(filepath, errors, hash_format, scenes, **kwargs)
         return [
             {

--- a/perception/hashers/video/framewise.py
+++ b/perception/hashers/video/framewise.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from .. import tools
@@ -17,7 +15,7 @@ class FramewiseHasher(VideoHasher):
         frame_hasher: ImageHasher,
         interframe_threshold: float,
         frames_per_second: int = 15,
-        quality_threshold: Optional[float] = None,
+        quality_threshold: float | None = None,
     ):
         self.hash_length = frame_hasher.hash_length
         self.frames_per_second = frames_per_second
@@ -25,10 +23,8 @@ class FramewiseHasher(VideoHasher):
         self.distance_metric = frame_hasher.distance_metric
         if self.distance_metric == "hamming" and interframe_threshold > 1:
             raise ValueError(
-                (
-                    "Hamming distance is always between 0 and 1 but "
-                    f"`interframe_threshold` was set to {interframe_threshold}."
-                )
+                "Hamming distance is always between 0 and 1 but "
+                f"`interframe_threshold` was set to {interframe_threshold}."
             )
         self.dtype = frame_hasher.dtype
         self.interframe_threshold = interframe_threshold

--- a/perception/hashers/video/scenes.py
+++ b/perception/hashers/video/scenes.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 import cv2
 import numpy as np
@@ -37,7 +36,7 @@ class SimpleSceneDetection(VideoHasher):
 
     def __init__(
         self,
-        base_hasher: Optional[VideoHasher] = None,
+        base_hasher: VideoHasher | None = None,
         interscene_threshold=None,
         min_frame_size=50,
         similarity_threshold=0.95,
@@ -131,12 +130,10 @@ class SimpleSceneDetection(VideoHasher):
         if subhash is not None and (
             self.base_hasher.returns_multiple
             or (
-                (
-                    self.interscene_threshold is None
-                    or not state["scenes"]
-                    or self.compute_distance(state["scenes"][-1]["hash"], subhash)
-                    > self.interscene_threshold
-                )
+                self.interscene_threshold is None
+                or not state["scenes"]
+                or self.compute_distance(state["scenes"][-1]["hash"], subhash)
+                > self.interscene_threshold
             )
         ):
             # Persist the scene's hash, frames, start timestamp, and end timestamp.

--- a/perception/hashers/video/tmk.py
+++ b/perception/hashers/video/tmk.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import platform
 import warnings
 
@@ -17,7 +16,7 @@ class TMKL2(VideoHasher):
 
     def __init__(
         self,
-        frame_hasher: Optional[ImageHasher] = None,
+        frame_hasher: ImageHasher | None = None,
         frames_per_second: int = 15,
         normalization: str = "matrix",
     ):
@@ -119,23 +118,23 @@ class TMKL2(VideoHasher):
             fv_b = fv_b / norm_b
 
         if "freq" in normalization:
-            norm_a, norm_b = [
+            norm_a, norm_b = (
                 np.sqrt((fv**2).sum(axis=1, keepdims=True) / self.m + eps) + eps
                 for fv in [fv_a, fv_b]
-            ]
+            )
             fv_a = fv_a / norm_a
             fv_b = fv_b / norm_b
 
         if normalization == "matrix":
-            norm_a, norm_b = [
+            norm_a, norm_b = (
                 np.sqrt(np.sum(fv**2, axis=(1, 2)) + eps)[..., np.newaxis] + eps
                 for fv in [fv_a, fv_b]
-            ]  # (T, 1)
+            )  # (T, 1)
 
-        fv_a_sin, fv_b_sin = [fv[:, : self.m] for fv in [fv_a, fv_b]]  # (T, m, d)
-        fv_a_cos, fv_b_cos = [fv[:, self.m :] for fv in [fv_a, fv_b]]  # (T, m, d)
+        fv_a_sin, fv_b_sin = (fv[:, : self.m] for fv in [fv_a, fv_b])  # (T, m, d)
+        fv_a_cos, fv_b_cos = (fv[:, self.m :] for fv in [fv_a, fv_b])  # (T, m, d)
         ms = self.ms.reshape(-1, 1)  # (m, 1)
-        dot_sin_sin, dot_sin_cos, dot_cos_cos, dot_cos_sin = [
+        dot_sin_sin, dot_sin_cos, dot_cos_cos, dot_cos_sin = (
             np.sum(p, axis=2, keepdims=True)
             for p in [
                 fv_a_sin * fv_b_sin,
@@ -143,7 +142,7 @@ class TMKL2(VideoHasher):
                 fv_a_cos * fv_b_cos,
                 fv_a_cos * fv_b_sin,
             ]
-        ]  # (T, m, 1)
+        )  # (T, m, 1)
         delta = (
             ms.reshape(1, -1, 1) * offsets.reshape(1, -1) / self.T.reshape((-1, 1, 1))
         )
@@ -169,7 +168,7 @@ class TMKL1(VideoHasher):
 
     def __init__(
         self,
-        frame_hasher: Optional[ImageHasher] = None,
+        frame_hasher: ImageHasher | None = None,
         frames_per_second: int = 15,
         dtype="float32",
         distance_metric="cosine",

--- a/perception/testing/__init__.py
+++ b/perception/testing/__init__.py
@@ -127,7 +127,7 @@ def test_hasher_parallelization(hasher, test_filepaths):
 
 
 def test_video_hasher_integrity(
-    hasher: hashers.VideoHasher, test_videos: typing.List[str] = DEFAULT_TEST_VIDEOS
+    hasher: hashers.VideoHasher, test_videos: list[str] = DEFAULT_TEST_VIDEOS
 ):
     test_hasher_parallelization(hasher, test_videos)
 
@@ -136,7 +136,7 @@ def test_image_hasher_integrity(
     hasher: hashers.ImageHasher,
     pil_opencv_threshold: float,
     transform_threshold: float,
-    test_images: typing.List[str] = DEFAULT_TEST_IMAGES,
+    test_images: list[str] = DEFAULT_TEST_IMAGES,
     opencv_hasher: bool = False,
 ):
     """Test to ensure a hasher works correctly.

--- a/perception/tools.py
+++ b/perception/tools.py
@@ -1,11 +1,9 @@
 import base64
 import json
 import os
-import typing
 import urllib.parse
 import urllib.request
 import warnings
-from typing import Optional
 
 import numpy as np
 from scipy import spatial
@@ -25,9 +23,7 @@ except ImportError:
     extensions = None
 
 
-def _multiple_hashes_for_ids(
-    hashes: typing.List[typing.Tuple[str, typing.Union[str, np.ndarray]]]
-):
+def _multiple_hashes_for_ids(hashes: list[tuple[str, str | np.ndarray]]):
     """Check if a list of (hash_id, hash) tuples has more
     than one hash for a hash_id.
 
@@ -39,15 +35,15 @@ def _multiple_hashes_for_ids(
 
 
 def deduplicate_hashes(
-    hashes: typing.List[typing.Tuple[str, typing.Union[str, np.ndarray]]],
+    hashes: list[tuple[str, str | np.ndarray]],
     threshold: float,
     hash_format: str = "base64",
-    hasher: Optional[perception_hashers.ImageHasher] = None,
-    hash_length: Optional[int] = None,
-    hash_dtype: Optional[str] = None,
-    distance_metric: Optional[str] = None,
-    progress: Optional[tqdm] = None,
-) -> typing.List[typing.Tuple[str, str]]:
+    hasher: perception_hashers.ImageHasher | None = None,
+    hash_length: int | None = None,
+    hash_dtype: str | None = None,
+    distance_metric: str | None = None,
+    progress: tqdm | None = None,
+) -> list[tuple[str, str]]:
     """Find duplicates using a list of precomputed hashes.
 
     Args:
@@ -102,7 +98,7 @@ def deduplicate_hashes(
         ]
     )
     files = np.array([identifier for identifier, _ in hashes])
-    pairs: typing.List[typing.Tuple[str, str]] = []
+    pairs: list[tuple[str, str]] = []
     n_hashes = len(vectors)
     start_idx = 0
     end_idx = None
@@ -134,7 +130,7 @@ def deduplicate_hashes(
         # this so we can pass it to the compute_euclidean_pairwise_duplicates
         # function.
         if multiple_hashes_per_id:
-            counts = np.zeros(shape=len(set(hash_id for hash_id, _ in hashes))).astype(
+            counts = np.zeros(shape=len({hash_id for hash_id, _ in hashes})).astype(
                 "uint32"
             )
             previous_hash_id = None
@@ -162,11 +158,11 @@ def deduplicate_hashes(
 
 
 def deduplicate(
-    files: typing.List[str],
-    hashers: typing.List[typing.Tuple[perception_hashers.ImageHasher, float]],
+    files: list[str],
+    hashers: list[tuple[perception_hashers.ImageHasher, float]],
     isometric: bool = False,
-    progress: Optional[tqdm] = None,
-) -> typing.List[typing.Tuple[str, str]]:
+    progress: tqdm | None = None,
+) -> list[tuple[str, str]]:
     """Find duplicates in a list of files.
 
     Args:
@@ -187,7 +183,7 @@ def deduplicate(
             category=UserWarning,
         )
         files = list(files_dedup)
-    pairs: typing.List[typing.Tuple[str, str]] = []
+    pairs: list[tuple[str, str]] = []
     for hasher_idx, (hasher, threshold) in enumerate(hashers):
         hash_dicts = hasher.compute_parallel(
             filepaths=files,
@@ -271,12 +267,12 @@ class SaferMatcher:
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
-        url: Optional[str] = None,
-        hasher: Optional[perception_hashers.ImageHasher] = None,
-        hasher_api_id: Optional[str] = None,
+        api_key: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        url: str | None = None,
+        hasher: perception_hashers.ImageHasher | None = None,
+        hasher_api_id: str | None = None,
         quality_threshold: int = 90,
     ):
         if (
@@ -322,11 +318,7 @@ class SaferMatcher:
 
     def match(
         self,
-        images: typing.List[
-            typing.Union[
-                str, typing.Tuple[perception_hashers.tools.ImageInputType, str]
-            ]
-        ],
+        images: list[(str | tuple[perception_hashers.tools.ImageInputType, str])],
     ) -> dict:
         """Match hashes with the Safer matching service.
 


### PR DESCRIPTION
* Modernize the Python Syntax for 3.10

This shold not change any functionality. It updates the way that the Python is written to more to modern Python style.

* Remove Unneeded Forward Reference