### PR TITLE
Bootstrapping GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,31 @@
+name: Deploy Sphinx documentation to Pages
+
+on:
+  push:
+    branches:
+      - dunnack/sphinx-to-github-pages
+      - main
+    paths:
+      - .github/workflows/gh-pages.yaml
+      - docs/**
+
+jobs:
+  pages:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: deployment
+        uses: sphinx-notes/pages@v3
+        with:
+          checkout: false
+          documentation_path: docs
+          requirements_path: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
-sphinx-autodoc-typehints==1.6.0
-sphinx-autobuild==0.7.1
-sphinx==1.8.3
-sphinx_rtd_theme==0.4.3
-m2r==0.2.1
+sphinx-autodoc-typehints==3.2.0
+# sphinx-autobuild==3.0.2
+# sphinx==1.8.3
+sphinx_rtd_theme==3.0.2
+m2r==0.3.1
 opencv-contrib-python-headless
 tqdm
 imgaug


### PR DESCRIPTION
## Ticket

TOOLSMITHS-2175

## Description

This pull request introduces a workflow to deploy Sphinx documentation to GitHub Pages and updates the Sphinx-related dependencies in `docs/requirements.txt`. These changes aim to automate documentation deployment and modernize the Sphinx toolchain.

### Deployment Workflow:

* Added a new GitHub Actions workflow (`.github/workflows/gh-pages.yaml`) to deploy Sphinx documentation to GitHub Pages. The workflow triggers on pushes to the `main` branch or the `dunnack/sphinx-to-github-pages` branch and includes steps to check out the repository and deploy using the `sphinx-notes/pages` action.

### Dependency Updates:

* Updated `sphinx-autodoc-typehints` to version `3.2.0` and `sphinx_rtd_theme` to version `3.0.2` in `docs/requirements.txt`. Additionally, updated `m2r` to version `0.3.1` and commented out `sphinx-autobuild` and `sphinx` dependencies, likely to address compatibility or deprecation issues.