### PR TITLE
Add SpooledTemporaryFile as ImageInputType

### DIFF
--- a/perception/hashers/tools.py
+++ b/perception/hashers/tools.py
@@ -11,6 +11,7 @@ import os
 import queue
 import shlex
 import subprocess
+import tempfile
 import threading
 import typing
 import warnings
@@ -27,7 +28,7 @@ import validators
 
 LOGGER = logging.getLogger(__name__)
 
-ImageInputType = typing.Union[str, np.ndarray, "PIL.Image.Image", io.BytesIO]
+ImageInputType = typing.Union[str, np.ndarray, "PIL.Image.Image", io.BytesIO, tempfile.SpooledTemporaryFile]
 
 SIZES = {"float32": 32, "uint8": 8, "bool": 1}
 
@@ -357,7 +358,7 @@ def read(filepath_or_buffer: ImageInputType, timeout=None) -> np.ndarray:
     """
     if isinstance(filepath_or_buffer, PIL.Image.Image):
         return np.array(filepath_or_buffer.convert("RGB"))
-    if isinstance(filepath_or_buffer, (io.BytesIO, client.HTTPResponse)):
+    if isinstance(filepath_or_buffer, (io.BytesIO, client.HTTPResponse, tempfile.SpooledTemporaryFile)):
         image = np.asarray(bytearray(filepath_or_buffer.read()), dtype=np.uint8)
         decoded_image = cv2.imdecode(image, cv2.IMREAD_UNCHANGED)
     elif isinstance(filepath_or_buffer, str):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+import io
 
 import numpy as np
 import pytest
@@ -241,3 +242,20 @@ def test_ffmpeg_video():
                 timestamp1, timestamp2
             ), f"Timestamp mismatch for {filename}"
             assert np.percentile(diff, 75) < 25, f"Frame mismatch for {filename}"
+
+
+def test_image_input_types():
+    image_expected = hashers.tools.read(testing.DEFAULT_TEST_IMAGES[0])
+
+    with open(testing.DEFAULT_TEST_IMAGES[0], "rb") as f:
+        image_data = f.read()
+
+    image_bytes_io = hashers.tools.read(io.BytesIO(image_data))
+    assert (image_expected == image_bytes_io).all()
+
+    with tempfile.SpooledTemporaryFile() as f:
+        f.write(image_data)
+        f.seek(0)
+        image_tempfile = hashers.tools.read(f)
+
+    assert (image_expected == image_tempfile).all()


### PR DESCRIPTION
SpooledTemporaryFile is used as a backend by some HTTP frameworks for storing form file data.

Werkzeug example: https://github.com/pallets/werkzeug/blob/504a8c4fbda9b8b2fd09e817544ffd228f23458e/src/werkzeug/formparser.py#L62

I've added it to list of image input files and extended tests to cover it.