### PR TITLE
Potential fix for code scanning alert no. 5010: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
       - "**"
     tags-ignore:
       - v*
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/thorn-oss/perception/security/code-scanning/5010](https://github.com/thorn-oss/perception/security/code-scanning/5010)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yaml` so all jobs default to least privilege.  
Best fix here: add:

```yaml
permissions:
  contents: read
```

directly under the `on:` trigger block (before `jobs:`). This preserves current behavior while documenting and enforcing minimal token scope for checkout and read operations. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
