### PR TITLE
Potential fix for code scanning alert no. 5012: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/thorn-oss/perception/security/code-scanning/5012](https://github.com/thorn-oss/perception/security/code-scanning/5012)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/release.yaml` so all jobs inherit restricted token access by default.

Best fix (minimal and non-breaking): add:

```yaml
permissions:
  contents: read
```

immediately after the `on:` trigger section (before `jobs:`). This satisfies CodeQL’s requirement and preserves existing behavior for `actions/checkout` (which needs `contents: read`) while avoiding unnecessary write scopes. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
