### PR TITLE
Move Heavy Dependencies into Extras

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,17 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
+        # Limit to package sources; `[tool.mypy] exclude` is ignored when
+        # pre-commit passes file paths as arguments.
+        files: ^perception/
+        # mirrors-mypy runs in an isolated env, so re-list any deps mypy
+        # needs to follow imports / type-check our code. Keep in sync
+        # with the dev dependency group in pyproject.toml.
+        additional_dependencies:
+          - numpy>=1.26.4,<3.0.0
+          - pandas
+          - pandas-stubs
+          - scipy
+          - typing_extensions>=4.0,<5.0
+          - types-pillow
+          - types-tqdm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-05-13
+This release moves heavyweight approximate-deduplication dependencies behind an optional extra so they are not installed for users who only need core hashing functionality.
+
+### Breaking changes
+- `faiss-cpu`, `networkit`, and `networkx` are no longer core dependencies. Users of `perception.approximate_deduplication` or `perception.local_descriptor_deduplication` must now install the new `approximate-deduplication` extra: `pip install perception[approximate-deduplication]`. Importing those modules without the extra raises an `ImportError` with installation instructions.
+- `pandas` is no longer a core dependency. It is pulled in automatically by the `approximate-deduplication` and `benchmarking` extras (the only modules that use it). Code that imports `perception.benchmarking`, `perception.approximate_deduplication`, `perception.local_descriptor_deduplication`, or `perception.testing` should install the appropriate extra.
+
 ## [0.4.0] - 2020-10-17
 This release switches from using false positive rates in benchmarking to reporting precision, which is more intuitive.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.9.0] - 2026-05-13
-This release moves heavyweight approximate-deduplication dependencies behind an optional extra so they are not installed for users who only need core hashing functionality.
+This release moves heavyweight dependencies behind optional extras so they are not installed for users who only need core hashing functionality, and standardizes the error users see when an extra is missing.
 
 ### Breaking changes
-- `faiss-cpu`, `networkit`, and `networkx` are no longer core dependencies. Users of `perception.approximate_deduplication` or `perception.local_descriptor_deduplication` must now install the new `approximate-deduplication` extra: `pip install perception[approximate-deduplication]`. Importing those modules without the extra raises an `ImportError` with installation instructions.
-- `pandas` is no longer a core dependency. It is pulled in automatically by the `approximate-deduplication` and `benchmarking` extras (the only modules that use it). Code that imports `perception.benchmarking`, `perception.approximate_deduplication`, `perception.local_descriptor_deduplication`, or `perception.testing` should install the appropriate extra.
+- `faiss-cpu`, `networkit`, and `networkx` are no longer core dependencies. They are pulled in by the new `approximate-deduplication` extra (`pip install perception[approximate-deduplication]`), which is required to use `perception.approximate_deduplication` or `perception.local_descriptor_deduplication`.
+- `pandas` is no longer a core dependency. It is pulled in by the `approximate-deduplication` and `benchmarking` extras (the only modules that use it). Code that imports `perception.benchmarking`, `perception.approximate_deduplication`, `perception.local_descriptor_deduplication`, or `perception.testing` should install the appropriate extra.
+
+### Enhancements
+- All optional-dependency import sites — across the `approximate-deduplication`, `benchmarking`, `matching`, and `pdq` extras — now raise a uniform, actionable `ImportError` pointing at the correct `pip install perception[<extra>]` command when the relevant extra is not installed. This is implemented via a single helper, `perception._optional.import_optional`.
+- `typing_extensions` is now an explicit core dependency (it was previously transitive via `faiss-cpu` / `pandas`).
 
 ## [0.4.0] - 2020-10-17
 This release switches from using false positive rates in benchmarking to reporting precision, which is more intuitive.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 `perception` provides optional extras for additional functionality:
 
+- `approximate-deduplication` – FAISS-based approximate-nearest-neighbor
+  deduplication and graph community/clique detection (used by
+  `perception.approximate_deduplication` and
+  `perception.local_descriptor_deduplication`)
 - `benchmarking` – tools for benchmarking perceptual hashes
 - `matching` – async matching utilities
 - `pdq` – Facebook's PDQ hash support

--- a/perception/_optional.py
+++ b/perception/_optional.py
@@ -1,0 +1,33 @@
+"""Helpers for importing optional dependencies with friendly error messages."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+def import_optional(package: str, *, extra: str) -> Any:
+    """Import ``package`` or raise ``ImportError`` pointing at ``extra``.
+
+    Returns the imported module typed as ``Any`` so that attribute access
+    (including in type annotations like ``pd.DataFrame``) is not flagged
+    by static type checkers when the optional package is not installed in
+    the type-checking environment.
+
+    Parameters
+    ----------
+    package:
+        The importable module name (e.g. ``"faiss"``, ``"pandas"``).
+    extra:
+        The name of the ``perception`` extra that provides ``package``
+        (e.g. ``"approximate-deduplication"``).
+    """
+    try:
+        return importlib.import_module(package)
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover - exercised only without extra installed
+        raise ImportError(
+            f"`{package}` is required for this functionality. Install the "
+            f"'{extra}' extra with `pip install perception[{extra}]`."
+        ) from exc

--- a/perception/_optional.py
+++ b/perception/_optional.py
@@ -25,8 +25,17 @@ def import_optional(package: str, *, extra: str) -> Any:
     try:
         return importlib.import_module(package)
     except (
-        ImportError
+        ModuleNotFoundError
     ) as exc:  # pragma: no cover - exercised only without extra installed
+        # Only convert to the friendly "install the extra" hint when the
+        # missing module is the optional package itself (or a submodule of
+        # it). If the optional package is installed but one of its own
+        # imports failed, re-raise the original error so the real cause is
+        # not hidden.
+        missing = exc.name or ""
+        top_level = package.split(".", 1)[0]
+        if missing != top_level and not missing.startswith(top_level + "."):
+            raise
         raise ImportError(
             f"`{package}` is required for this functionality. Install the "
             f"'{extra}' extra with `pip install perception[{extra}]`."

--- a/perception/approximate_deduplication/__init__.py
+++ b/perception/approximate_deduplication/__init__.py
@@ -3,7 +3,14 @@ import math
 import os.path as op
 import typing
 
-import faiss
+try:
+    import faiss
+except ImportError as exc:  # pragma: no cover - exercised only without extra installed
+    raise ImportError(
+        "perception.approximate_deduplication requires the "
+        "'approximate-deduplication' extra. Install it with "
+        "`pip install perception[approximate-deduplication]`."
+    ) from exc
 import numpy as np
 import tqdm
 import typing_extensions

--- a/perception/approximate_deduplication/__init__.py
+++ b/perception/approximate_deduplication/__init__.py
@@ -3,19 +3,15 @@ import math
 import os.path as op
 import typing
 
-try:
-    import faiss
-except ImportError as exc:  # pragma: no cover - exercised only without extra installed
-    raise ImportError(
-        "perception.approximate_deduplication requires the "
-        "'approximate-deduplication' extra. Install it with "
-        "`pip install perception[approximate-deduplication]`."
-    ) from exc
 import numpy as np
 import tqdm
 import typing_extensions
 
-from ._graph_backend import get_graph_backend
+from perception._optional import import_optional
+
+faiss = import_optional("faiss", extra="approximate-deduplication")
+
+from ._graph_backend import get_graph_backend  # noqa: E402  (must follow faiss check)
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_PCT_PROBE = 0

--- a/perception/approximate_deduplication/_graph_backend.py
+++ b/perception/approximate_deduplication/_graph_backend.py
@@ -26,9 +26,21 @@ class GraphBackend(ABC):
     ) -> list[list[int]]: ...
 
 
+_EXTRA_INSTALL_HINT = (
+    "perception.approximate_deduplication requires the "
+    "'approximate-deduplication' extra. Install it with "
+    "`pip install perception[approximate-deduplication]`."
+)
+
+
 class NetworkitGraphBackend(GraphBackend):
     def __init__(self):
-        import networkit as nk
+        try:
+            import networkit as nk
+        except (
+            ImportError
+        ) as exc:  # pragma: no cover - exercised only without extra installed
+            raise ImportError(_EXTRA_INSTALL_HINT) from exc
 
         self.nk = nk
 
@@ -83,7 +95,12 @@ class NetworkitGraphBackend(GraphBackend):
 
 class NetworkxGraphBackend(GraphBackend):
     def __init__(self):
-        import networkx as nx
+        try:
+            import networkx as nx
+        except (
+            ImportError
+        ) as exc:  # pragma: no cover - exercised only without extra installed
+            raise ImportError(_EXTRA_INSTALL_HINT) from exc
 
         self.nx = nx
 

--- a/perception/approximate_deduplication/_graph_backend.py
+++ b/perception/approximate_deduplication/_graph_backend.py
@@ -2,6 +2,8 @@ import sys
 import typing
 from abc import ABC, abstractmethod
 
+from perception._optional import import_optional
+
 
 class GraphBackend(ABC):
     @abstractmethod
@@ -26,23 +28,9 @@ class GraphBackend(ABC):
     ) -> list[list[int]]: ...
 
 
-_EXTRA_INSTALL_HINT = (
-    "perception.approximate_deduplication requires the "
-    "'approximate-deduplication' extra. Install it with "
-    "`pip install perception[approximate-deduplication]`."
-)
-
-
 class NetworkitGraphBackend(GraphBackend):
     def __init__(self):
-        try:
-            import networkit as nk
-        except (
-            ImportError
-        ) as exc:  # pragma: no cover - exercised only without extra installed
-            raise ImportError(_EXTRA_INSTALL_HINT) from exc
-
-        self.nk = nk
+        self.nk = import_optional("networkit", extra="approximate-deduplication")
 
     def build_graph(
         self, node_count: int, edges: typing.Iterable[tuple[int, int]]
@@ -95,14 +83,7 @@ class NetworkitGraphBackend(GraphBackend):
 
 class NetworkxGraphBackend(GraphBackend):
     def __init__(self):
-        try:
-            import networkx as nx
-        except (
-            ImportError
-        ) as exc:  # pragma: no cover - exercised only without extra installed
-            raise ImportError(_EXTRA_INSTALL_HINT) from exc
-
-        self.nx = nx
+        self.nx = import_optional("networkx", extra="approximate-deduplication")
 
     def build_graph(
         self, node_count: int, edges: typing.Iterable[tuple[int, int]]

--- a/perception/approximate_deduplication/index.py
+++ b/perception/approximate_deduplication/index.py
@@ -2,7 +2,14 @@ import time
 import typing
 import warnings
 
-import faiss
+try:
+    import faiss
+except ImportError as exc:  # pragma: no cover - exercised only without extra installed
+    raise ImportError(
+        "perception.approximate_deduplication requires the "
+        "'approximate-deduplication' extra. Install it with "
+        "`pip install perception[approximate-deduplication]`."
+    ) from exc
 import numpy as np
 import pandas as pd
 import typing_extensions

--- a/perception/approximate_deduplication/index.py
+++ b/perception/approximate_deduplication/index.py
@@ -1,20 +1,20 @@
 import time
 import typing
 import warnings
+from typing import TYPE_CHECKING
 
-try:
-    import faiss
-except ImportError as exc:  # pragma: no cover - exercised only without extra installed
-    raise ImportError(
-        "perception.approximate_deduplication requires the "
-        "'approximate-deduplication' extra. Install it with "
-        "`pip install perception[approximate-deduplication]`."
-    ) from exc
 import numpy as np
-import pandas as pd
 import typing_extensions
 
 import perception.hashers.tools as pht
+from perception._optional import import_optional
+
+if TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = import_optional("pandas", extra="approximate-deduplication")
+
+faiss = import_optional("faiss", extra="approximate-deduplication")
 
 
 class QueryInput(typing_extensions.TypedDict):

--- a/perception/approximate_deduplication/serve.py
+++ b/perception/approximate_deduplication/serve.py
@@ -4,13 +4,15 @@ import json
 import logging
 import typing
 
-import aiohttp.web
 import numpy as np
-from pythonjsonlogger import jsonlogger
 
 import perception.hashers.tools as pht
+from perception._optional import import_optional
 
 from .index import ApproximateNearestNeighbors
+
+aiohttp_web = import_optional("aiohttp.web", extra="matching")
+jsonlogger = import_optional("pythonjsonlogger.jsonlogger", extra="matching")
 
 
 def is_similarity_valid(data, index: ApproximateNearestNeighbors):
@@ -54,13 +56,13 @@ async def similarity(request):
     try:
         request_data = await request.json()
     except json.JSONDecodeError:
-        return aiohttp.web.json_response({"reason": "Malformed JSON"}, status=400)
+        return aiohttp_web.json_response({"reason": "Malformed JSON"}, status=400)
 
     index = request.app["index"]
     try:
         assert is_similarity_valid(request_data, index)
     except Exception:
-        return aiohttp.web.json_response({"reason": "Invalid JSON request"}, status=400)
+        return aiohttp_web.json_response({"reason": "Invalid JSON request"}, status=400)
 
     async with request.app["query_semaphore"]:
         matches = await asyncio.get_event_loop().run_in_executor(
@@ -78,7 +80,7 @@ async def similarity(request):
         )
         matches = json.loads(json.dumps({"queries": matches}))
 
-    return aiohttp.web.json_response(matches)
+    return aiohttp_web.json_response(matches)
 
 
 def get_logger(name, log_level):
@@ -133,7 +135,7 @@ async def serve(
     """
     logger = get_logger(name="serve", log_level=log_level)
     logger.info("Initializing web service")
-    app = aiohttp.web.Application()
+    app = aiohttp_web.Application()
     app.router.add_post("/v1/similarity", similarity, name="similarity")
 
     # Store globals in the application object
@@ -144,8 +146,8 @@ async def serve(
     app["index"] = index
     app["query_semaphore"] = asyncio.Semaphore(concurrency)
     logger.info("Entering web service listener loop.")
-    runner = aiohttp.web.AppRunner(app, logger=logger)
+    runner = aiohttp_web.AppRunner(app, logger=logger)
     await runner.setup()
-    site = aiohttp.web.TCPSite(runner, host, port)
+    site = aiohttp_web.TCPSite(runner, host, port)
     await site.start()
     return site

--- a/perception/benchmarking/common.py
+++ b/perception/benchmarking/common.py
@@ -7,14 +7,21 @@ import uuid
 import warnings
 import zipfile
 from abc import ABC
+from typing import TYPE_CHECKING
 
-import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import tqdm
 from scipy import spatial, stats
 
+from .._optional import import_optional
 from ..hashers.tools import compute_md5, string_to_vector
+
+if TYPE_CHECKING:
+    import matplotlib.pyplot as plt
+    import pandas as pd
+else:
+    plt = import_optional("matplotlib.pyplot", extra="benchmarking")
+    pd = import_optional("pandas", extra="benchmarking")
 
 try:
     from . import extensions  # type: ignore

--- a/perception/benchmarking/image.py
+++ b/perception/benchmarking/image.py
@@ -2,16 +2,23 @@ import logging
 import os
 import uuid
 import warnings
+from typing import TYPE_CHECKING
 
 import cv2
-import albumentations
-import pandas as pd
 from tqdm import tqdm
 
+from .._optional import import_optional
 from ..hashers import tools
 from ..hashers.hasher import ImageHasher
 from ..tools import deduplicate, flatten
 from .common import BenchmarkDataset, BenchmarkHashes, BenchmarkTransforms
+
+if TYPE_CHECKING:
+    import albumentations
+    import pandas as pd
+else:
+    albumentations = import_optional("albumentations", extra="benchmarking")
+    pd = import_optional("pandas", extra="benchmarking")
 
 log = logging.getLogger(__name__)
 

--- a/perception/benchmarking/video.py
+++ b/perception/benchmarking/video.py
@@ -3,12 +3,14 @@ import os
 import typing
 import uuid
 
-import pandas as pd
 import tqdm
 
+from .._optional import import_optional
 from ..hashers import VideoHasher, tools
 from ..tools import flatten
 from .common import BenchmarkDataset, BenchmarkHashes, BenchmarkTransforms
+
+pd = import_optional("pandas", extra="benchmarking")
 
 
 def _process_row(row, hashers, framerates):

--- a/perception/benchmarking/video_transforms.py
+++ b/perception/benchmarking/video_transforms.py
@@ -1,9 +1,11 @@
 import os
 
 import cv2
-import ffmpeg
 
+from .._optional import import_optional
 from ..hashers.tools import read_video
+
+ffmpeg = import_optional("ffmpeg", extra="benchmarking")
 
 
 def probe(filepath):

--- a/perception/hashers/hasher.py
+++ b/perception/hashers/hasher.py
@@ -287,7 +287,6 @@ class ImageHasher(Hasher):
 
 
 class VideoHasher(Hasher):
-
     #: The frame rate at which videos are read
     frames_per_second: float = 1
 

--- a/perception/hashers/image/pdq.py
+++ b/perception/hashers/image/pdq.py
@@ -1,6 +1,7 @@
-import pdqhash
-
+from ..._optional import import_optional
 from ..hasher import ImageHasher
+
+pdqhash = import_optional("pdqhash", extra="pdq")
 
 
 class PDQHash(ImageHasher):

--- a/perception/local_descriptor_deduplication.py
+++ b/perception/local_descriptor_deduplication.py
@@ -2,16 +2,22 @@ import concurrent.futures
 import logging
 import typing
 from abc import ABC
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import cv2
 import numpy as np
-import pandas as pd
 import tqdm
 import typing_extensions
 
 import perception.approximate_deduplication as ad
 import perception.hashers.tools as pht
+from perception._optional import import_optional
+
+if TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = import_optional("pandas", extra="approximate-deduplication")
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_MAX_FEATURES = 256
@@ -157,7 +163,7 @@ class LocalHasher(ABC):
             descriptorB["descriptors"].astype("float32"), 2
         )
         good_A2B, good_B2A = map(
-            lambda distances: (distances[:, 0] < distances[:, 1] * self.ratio),
+            lambda distances: distances[:, 0] < distances[:, 1] * self.ratio,
             [distances_A2B, distances_B2A],
         )
         match = min(

--- a/perception/testing/__init__.py
+++ b/perception/testing/__init__.py
@@ -6,11 +6,13 @@ from importlib import resources
 
 import cv2
 import numpy as np
-import pandas as pd
 import pytest
 from PIL import Image
 
 from .. import hashers, tools
+from .._optional import import_optional
+
+pd = import_optional("pandas", extra="benchmarking")
 
 SIZES = {"float32": 32, "uint8": 8, "bool": 1}
 

--- a/perception/tools.py
+++ b/perception/tools.py
@@ -136,8 +136,8 @@ def deduplicate_hashes(
             previous_hash_id = None
             counts_idx = 0
             files_ = (
-                []  # make type check happy
-            )  # We're going to re-build the IDs with deduplicated files.
+                []
+            )  # make type check happy  # We're going to re-build the IDs with deduplicated files.
             for hash_id, _ in hashes:
                 if hash_id != previous_hash_id:
                     files_.append(hash_id)
@@ -188,7 +188,7 @@ def deduplicate(
         hash_dicts = hasher.compute_parallel(
             filepaths=files,
             progress=progress,
-            progress_desc=f"Computing hashes for hash {hasher_idx+1} of {len(hashers)}.",
+            progress_desc=f"Computing hashes for hash {hasher_idx + 1} of {len(hashers)}.",
             isometric=isometric,
         )
         hash_list = sorted(hash_dicts, key=lambda h: h["filepath"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,6 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
   "numpy>=1.26.4,<3.0.0",
   "opencv-contrib-python-headless>=4.10.0,<5.0.0",
-  "faiss-cpu>=1.8.0,<2.0.0",
-  "networkit>=11.1,<12.0.0; sys_platform != 'darwin'",
-  "networkx>=3.0,<4.0; sys_platform == 'darwin'",
-  "pandas",
   "Pillow",
   "pywavelets>=1.5.0,<2.0.0",
   "validators>=0.22.0,<1.0.0",
@@ -23,9 +19,16 @@ dependencies = [
 
 
 [project.optional-dependencies]
+approximate-deduplication = [
+  "faiss-cpu>=1.8.0,<2.0.0",
+  "networkit>=11.1,<12.0.0; sys_platform != 'darwin'",
+  "networkx>=3.0,<4.0; sys_platform == 'darwin'",
+  "pandas",
+]
 benchmarking = [
   "matplotlib",
   "albumentations>=2.0.8,<3.0.0",
+  "pandas",
   "tabulate",
   "scikit-learn",
   "ffmpeg-python",
@@ -38,8 +41,12 @@ dev = [
   "albumentations>=2.0.8,<3.0.0",
   "black>=26,<27",
   "coverage",
+  "faiss-cpu>=1.8.0,<2.0.0",
   "ipython",
   "mypy",
+  "networkit>=11.1,<12.0.0; sys_platform != 'darwin'",
+  "networkx>=3.0,<4.0; sys_platform == 'darwin'",
+  "pandas",
   "pandas-stubs",
   "pre-commit",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "rich>=13.7.0,<14.0.0",
   "scipy",
   "tqdm>=4.67.1,<5.0.0",
+  "typing_extensions>=4.0,<5.0",
 ]
 
 
@@ -39,7 +40,7 @@ pdq = ["pdqhash>=0.2.7,<0.3.0"]
 [dependency-groups]
 dev = [
   "albumentations>=2.0.8,<3.0.0",
-  "black>=26,<27",
+  "black==26.3.1",
   "coverage",
   "faiss-cpu>=1.8.0,<2.0.0",
   "ipython",

--- a/tests/test_local_descriptor_deduplication.py
+++ b/tests/test_local_descriptor_deduplication.py
@@ -64,8 +64,10 @@ def test_deduplication(hasher):
     perfect = (
         clustered.groupby("cluster")
         .apply(
-            lambda g: g["guid"].nunique() == 1
-            and g["transform_name"].nunique() == n_transforms
+            lambda g: (
+                g["guid"].nunique() == 1
+                and g["transform_name"].nunique() == n_transforms
+            )
         )
         .sum()
     )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -277,9 +277,10 @@ def test_ffmpeg_video():
         ):
             diff = np.abs(frame1.astype("int32") - frame2.astype("int32")).flatten()
             assert index1 == index2, f"Index mismatch for {filename}"
-            np.testing.assert_allclose(
-                timestamp1, timestamp2
-            ), f"Timestamp mismatch for {filename}"
+            (
+                np.testing.assert_allclose(timestamp1, timestamp2),
+                f"Timestamp mismatch for {filename}",
+            )
             assert np.percentile(diff, 75) < 25, f"Frame mismatch for {filename}"
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -106,7 +106,14 @@ def test_compute_euclidean_pairwise_duplicates():
     # Use grouped files.
     counts = np.array([3, 3, 2, 2])
     expected = np.array(
-        [[2 / 3, 2 / 3], [0, 0], [0, 0], [1 / 3, 1 / 2], [0, 0], [0, 0]]
+        [
+            [2 / 3, 2 / 3],
+            [0, 0],
+            [0, 0],
+            [1 / 3, 1 / 2],
+            [0, 0],
+            [0, 0],
+        ]
     )
     actual = tools.extensions.compute_euclidean_pairwise_duplicates(
         X=X.astype("int32"),
@@ -277,9 +284,10 @@ def test_ffmpeg_video():
         ):
             diff = np.abs(frame1.astype("int32") - frame2.astype("int32")).flatten()
             assert index1 == index2, f"Index mismatch for {filename}"
-            (
-                np.testing.assert_allclose(timestamp1, timestamp2),
-                f"Timestamp mismatch for {filename}",
+            np.testing.assert_allclose(
+                timestamp1,
+                timestamp2,
+                err_msg=f"Timestamp mismatch for {filename}",
             )
             assert np.percentile(diff, 75) < 25, f"Frame mismatch for {filename}"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2345,15 +2345,9 @@ wheels = [
 name = "perception"
 source = { editable = "." }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "networkit", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "opencv-contrib-python-headless" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
     { name = "pywavelets", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pywavelets", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -2365,10 +2359,20 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+approximate-deduplication = [
+    { name = "faiss-cpu" },
+    { name = "networkit", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
 benchmarking = [
     { name = "albumentations" },
     { name = "ffmpeg-python" },
     { name = "matplotlib" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tabulate" },
@@ -2386,9 +2390,15 @@ dev = [
     { name = "albumentations" },
     { name = "black" },
     { name = "coverage" },
+    { name = "faiss-cpu" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mypy" },
+    { name = "networkit", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas-stubs", version = "3.0.0.260204", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pre-commit" },
@@ -2404,14 +2414,15 @@ dev = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'matching'" },
     { name = "albumentations", marker = "extra == 'benchmarking'", specifier = ">=2.0.8,<3.0.0" },
-    { name = "faiss-cpu", specifier = ">=1.8.0,<2.0.0" },
+    { name = "faiss-cpu", marker = "extra == 'approximate-deduplication'", specifier = ">=1.8.0,<2.0.0" },
     { name = "ffmpeg-python", marker = "extra == 'benchmarking'" },
     { name = "matplotlib", marker = "extra == 'benchmarking'" },
-    { name = "networkit", marker = "sys_platform != 'darwin'", specifier = ">=11.1,<12.0.0" },
-    { name = "networkx", marker = "sys_platform == 'darwin'", specifier = ">=3.0,<4.0" },
+    { name = "networkit", marker = "sys_platform != 'darwin' and extra == 'approximate-deduplication'", specifier = ">=11.1,<12.0.0" },
+    { name = "networkx", marker = "sys_platform == 'darwin' and extra == 'approximate-deduplication'", specifier = ">=3.0,<4.0" },
     { name = "numpy", specifier = ">=1.26.4,<3.0.0" },
     { name = "opencv-contrib-python-headless", specifier = ">=4.10.0,<5.0.0" },
-    { name = "pandas" },
+    { name = "pandas", marker = "extra == 'approximate-deduplication'" },
+    { name = "pandas", marker = "extra == 'benchmarking'" },
     { name = "pdqhash", marker = "extra == 'pdq'", specifier = ">=0.2.7,<0.3.0" },
     { name = "pillow" },
     { name = "python-json-logger", marker = "extra == 'matching'" },
@@ -2423,15 +2434,19 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1,<5.0.0" },
     { name = "validators", specifier = ">=0.22.0,<1.0.0" },
 ]
-provides-extras = ["benchmarking", "matching", "pdq"]
+provides-extras = ["approximate-deduplication", "benchmarking", "matching", "pdq"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "albumentations", specifier = ">=2.0.8,<3.0.0" },
     { name = "black", specifier = ">=26,<27" },
     { name = "coverage" },
+    { name = "faiss-cpu", specifier = ">=1.8.0,<2.0.0" },
     { name = "ipython" },
     { name = "mypy" },
+    { name = "networkit", marker = "sys_platform != 'darwin'", specifier = ">=11.1,<12.0.0" },
+    { name = "networkx", marker = "sys_platform == 'darwin'", specifier = ">=3.0,<4.0" },
+    { name = "pandas" },
     { name = "pandas-stubs" },
     { name = "pre-commit" },
     { name = "pytest" },

--- a/uv.lock
+++ b/uv.lock
@@ -2355,6 +2355,7 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
+    { name = "typing-extensions" },
     { name = "validators" },
 ]
 
@@ -2432,6 +2433,7 @@ requires-dist = [
     { name = "scipy" },
     { name = "tabulate", marker = "extra == 'benchmarking'" },
     { name = "tqdm", specifier = ">=4.67.1,<5.0.0" },
+    { name = "typing-extensions", specifier = ">=4.0,<5.0" },
     { name = "validators", specifier = ">=0.22.0,<1.0.0" },
 ]
 provides-extras = ["approximate-deduplication", "benchmarking", "matching", "pdq"]
@@ -2439,7 +2441,7 @@ provides-extras = ["approximate-deduplication", "benchmarking", "matching", "pdq
 [package.metadata.requires-dev]
 dev = [
     { name = "albumentations", specifier = ">=2.0.8,<3.0.0" },
-    { name = "black", specifier = ">=26,<27" },
+    { name = "black", specifier = "==26.3.1" },
     { name = "coverage" },
     { name = "faiss-cpu", specifier = ">=1.8.0,<2.0.0" },
     { name = "ipython" },


### PR DESCRIPTION
Move heavyweight dependencies to optional extras and update documentation. This makes it easier to add Perception in more places.