### PR TITLE
Add box_filter parameter to PHash for Zauner (2010)

### DIFF
--- a/perception/hashers/image/phash.py
+++ b/perception/hashers/image/phash.py
@@ -19,13 +19,21 @@ class PHash(ImageHasher):
             image to before computing the DCT.
         exclude_first_term: WHether to exclude the first term of the DCT
         freq_shift: The number of DCT low frequency elements to skip.
+        box_filter: Whether to apply a mean filter before resizing, as described
+            in Zauner (2010). To use this algorithm as described by Zauner (2010),
+            set highfreq_factor=4, hash_size=8, and box_filter=True.
     """
 
     distance_metric = "hamming"
     dtype = "bool"
 
     def __init__(
-        self, hash_size=8, highfreq_factor=4, exclude_first_term=False, freq_shift=0
+        self,
+        hash_size=8,
+        highfreq_factor=4,
+        exclude_first_term=False,
+        freq_shift=0,
+        box_filter=False,
     ):
         assert hash_size >= 2, "Hash size must be greater than or equal to 2"
         assert (
@@ -36,12 +44,16 @@ class PHash(ImageHasher):
         self.exclude_first_term = exclude_first_term
         self.hash_length = hash_size * hash_size
         self.freq_shift = freq_shift
+        self.box_filter = box_filter
         if exclude_first_term:
             self.hash_length -= 1
 
     def _compute_dct(self, image):
         img_size = self.hash_size * self.highfreq_factor
         image = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        if self.box_filter:
+            kernel_size = round(img_size * 7 / 32)
+            image = cv2.boxFilter(image, ddepth=-1, ksize=(kernel_size, kernel_size))
         image = cv2.resize(
             image, dsize=(img_size, img_size), interpolation=cv2.INTER_AREA
         )

--- a/tests/test_hashers.py
+++ b/tests/test_hashers.py
@@ -1,6 +1,7 @@
 import os
 import string
 
+import numpy as np
 import pytest
 
 from perception import hashers, testing
@@ -102,6 +103,18 @@ def test_synchronized_hashing():
             filepath=filepath, hashers=video_hashers
         )
         assert hashes1 == hashes2
+
+
+def test_phash_box_filter():
+    h_default = hashers.PHash(box_filter=False)
+    h_filtered = hashers.PHash(box_filter=True)
+
+    image = hashers.tools.read(testing.DEFAULT_TEST_IMAGES[0])
+
+    dct_default = h_default._compute_dct(image)
+    dct_filtered = h_filtered._compute_dct(image)
+
+    assert not np.array_equal(dct_default, dct_filtered)
 
 
 def test_hex_b64_conversion():


### PR DESCRIPTION
Fixes #12 

According to Zauner (2010) there has to be a 7x7 mean filter before resizing.
This PR implements this filter, as well as tests in tests/test_hashers.py

## Changes
- Added a `box_filter` parameter to `PHash.__init__` (defaults to `False` to
  preserve existing behavior)
- When `box_filter=True`, a mean filter is applied before resizing using
  `cv2.boxFilter` with a kernel size that scales linearly with the image size
- Added a test confirming the filter produces different DCT values than the
  unfiltered path

## Usage
To use PHash as described by Zauner (2010):
```python
h = PHash(hash_size=8, highfreq_factor=4, box_filter=True)