### PR TITLE
Guard TMKL2 reshape when feature length is not N times hash_length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug fixes
+
+- TMKL2 returns None when frame features cannot reshape to `(1, 1, N, hash_length)` instead of raising ValueError (#43).
+
 ## [0.9.1] - 2026-05-26
 
 ### Enhancements

--- a/perception/hashers/video/tmk.py
+++ b/perception/hashers/video/tmk.py
@@ -70,14 +70,19 @@ class TMKL2(VideoHasher):
 
     def hash_from_final_state(self, state):
         timestamps = np.array(state["timestamps"])
-        features = np.array(state["features"]).reshape(
-            (
-                1,
-                1,
-                timestamps.shape[0],
-                self.frame_hasher.hash_length,
-            )
-        )
+        features = np.asarray(state["features"])
+        n_frames = int(timestamps.shape[0])
+        hash_length = self.frame_hasher.hash_length
+        # Hard-coded (1, 1, N, hash_length) raises when size != N * 255 (#43).
+        # Do not invent a shorter last axis. Same hole: return None.
+        if (
+            n_frames == 0
+            or features.size == 0
+            or features.dtype == object
+            or features.size != n_frames * hash_length
+        ):
+            return None
+        features = features.reshape((1, 1, n_frames, hash_length))
         x = self.ms_normed * timestamps
         yw1 = np.sin(x) * self.a
         yw2 = np.cos(x) * self.a


### PR DESCRIPTION
# Guard TMKL2 reshape when feature length ≠ N×hash_length

Closes thorn-oss/perception#43.

## Repo rules (live 2026-08-23, thorn-oss/perception README Contributing + Makefile + CHANGELOG.md)

- No CONTRIBUTING.md. `.github` is dependabot.yaml + workflows only (no PR template).
- README Contributing: `make init`, then `make precommit`. File an issue first (this one exists).
- `make init` = `uv sync --all-extras` + `uv run pre-commit install`.
- `make precommit` = `uv lock --check`, ruff, mypy, `black --check`, `uv run pytest tests/` (same five commands as `.github/workflows/ci.yaml`).
- CHANGELOG.md is Keep a Changelog (live headings: Enhancements / Bug fixes / Breaking changes). No Unreleased section and no PR checkbox — Forest copies this packet's `CHANGELOG-UNRELEASED.md` into CHANGELOG.md when filing.
- TMKL2 returns None unless `features.size == N * hash_length`. Do not mint a shorter last axis.
- Commit message is `COMMIT.txt`. Author: Forest Savage <forestsavage03@gmail.com>.

## Checklist

- [ ] `make precommit`
- [ ] `uv run pytest tests/`

Boxes stay unchecked until Forest re-runs them when filing. Do not file with fake checks.

## Summary

`TMKL2.hash_from_final_state` always reshapes features to `(1, 1, N, frame_hasher.hash_length)`. Default `hash_length` is 255. When `features.size` is not `N * 255` (object array of non-vectors, or a different feature width) NumPy raises `ValueError` and `compute` dies.

This keeps the same four-axis layout. Return `None` when the array is empty, object-typed, or not exactly `N * hash_length` (same hole as TMKL1 on empty state). Do not invent a shorter last axis.

No new TMK math. No new hashers.

## Files

1. `perception/hashers/video/tmk.py` (`TMKL2.hash_from_final_state` reshape only)

## Validation

Box run 2026-08-22 11:05 PM AKDT on `/workspace/checkouts/thorn-perception` main `23faec2` (shallow, Linux, Python 3.13.5). Independent of #17. No new test file.

### `make precommit`

```
uv lock --check
Resolved 136 packages in 2ms
uv run ruff check perception tests
All checks passed!
uv run mypy perception
Success: no issues found in 30 source files
uv run black --check . || (echo '\nUnexpected format.' && exit 1)
All done! ✨ 🍰 ✨
38 files would be left unchanged.
uv run pytest tests/
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspace/checkouts/thorn-perception
configfile: pyproject.toml
plugins: cov-7.1.0
collected 59 items

tests/test_approximate_deduplication.py ...                              [  5%]
tests/test_benchmarking.py ......                                        [ 15%]
tests/test_hashers.py ......................                             [ 52%]
tests/test_local_descriptor_deduplication.py ...........                 [ 71%]
tests/test_tmk.py .                                                      [ 72%]
tests/test_tools.py ................                                     [100%]

=============================== warnings summary ===============================
tests/test_benchmarking.py: 5 warnings
tests/test_hashers.py: 5 warnings
  /usr/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=692347) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 59 passed, 10 warnings in 27.19s =======================
```

### `uv run pytest tests/`

```
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspace/checkouts/thorn-perception
configfile: pyproject.toml
plugins: cov-7.1.0
collected 59 items

tests/test_approximate_deduplication.py ...                              [  5%]
tests/test_benchmarking.py ......                                        [ 15%]
tests/test_hashers.py ......................                             [ 52%]
tests/test_local_descriptor_deduplication.py ...........                 [ 71%]
tests/test_tmk.py .                                                      [ 72%]
tests/test_tools.py ................                                     [100%]

=============================== warnings summary ===============================
tests/test_benchmarking.py: 5 warnings
tests/test_hashers.py: 5 warnings
  /usr/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=695545) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 59 passed, 10 warnings in 26.95s =======================
```

### size 983 / N 983 returns None

One-off snippet in this packet (`PROOF.py`, not added to the repo):

```
$ uv run python /workspace/playbooks/drafts-2026-08-22/PERC-43-tmk-reshape/PROOF.py
frame_hasher.hash_length 255
features.size 983
N 983
N * hash_length 250665
size == N * hash_length False
hash_from_final_state None
is None True
type NoneType
PROOF_OK
```

A 983-wide vector with 983 timestamps returns None, not a 1-wide hash.

## Out of scope

- perception #45 (`compute_parallel` spawn)
- perception #17 (Windows `cv2.imread` paths)
- Changing `process_frame` or `PHashF` None-on-blank-frame
- TMKL1
- Periods, Bessel weights, scoring, offsets

## How to review

The hard-coded last axis stays `hash_length`. A features array of size 983 with 983 timestamps returns `None` (not a 1-wide hash, not a throw). I am a volunteer; if you wanted a hard error instead of `None`, say so and I will stand down.

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.

If you wanted a hard error instead of None, I will stand down.