### PR TITLE
Read images on non-Latin Windows paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug fixes
+
+- Read images on non-Latin Windows paths via `np.fromfile` + `cv2.imdecode` instead of `cv2.imread` (#17).
+
 ## [0.9.1] - 2026-05-26
 
 ### Enhancements

--- a/perception/hashers/tools.py
+++ b/perception/hashers/tools.py
@@ -373,7 +373,12 @@ def read(filepath_or_buffer: ImageInputType, timeout=None) -> np.ndarray:
             raise FileNotFoundError(
                 "Could not find image at path: " + filepath_or_buffer
             )
-        decoded_image = cv2.imread(filepath_or_buffer)
+        # cv2.imread uses the C runtime path API and fails on
+        # non-Latin Windows paths (#17). np.fromfile is Python-side.
+        # Empty files must stay None so the ValueError below still fires
+        # (imdecode raises on a zero-length buffer).
+        buf = np.fromfile(filepath_or_buffer, dtype=np.uint8)
+        decoded_image = cv2.imdecode(buf, cv2.IMREAD_COLOR) if buf.size else None
     else:
         raise RuntimeError(
             "Unhandled filepath_or_buffer type: " + str(type(filepath_or_buffer))


### PR DESCRIPTION
# Read images on non-Latin Windows paths

Closes thorn-oss/perception#17.

## Repo rules (live 2026-08-23, thorn-oss/perception README Contributing + Makefile + CHANGELOG.md)

- No CONTRIBUTING.md. `.github` is dependabot.yaml + workflows only (no PR template).
- README Contributing: `make init`, then `make precommit`. File an issue first (this one exists).
- `make init` = `uv sync --all-extras` + `uv run pre-commit install`.
- `make precommit` = `uv lock --check`, ruff, mypy, `black --check`, `uv run pytest tests/` (same five commands as `.github/workflows/ci.yaml`).
- CHANGELOG.md is Keep a Changelog (live headings: Enhancements / Bug fixes / Breaking changes). No Unreleased section and no PR checkbox — Forest copies this packet's `CHANGELOG-UNRELEASED.md` into CHANGELOG.md when filing.
- Empty file: `decoded_image` stays None so the existing `ValueError` still fires.
- Commit message is `COMMIT.txt`. Author: Forest Savage <forestsavage03@gmail.com>.

## Checklist

- [ ] `make precommit`
- [ ] `uv run pytest tests/`

Boxes stay unchecked until Forest re-runs them when filing. Do not file with fake checks.

## Summary

`hashers.tools.read` still calls `cv2.imread` for filesystem paths. That fails for non-Latin Windows paths. The same function already decodes buffers with `cv2.imdecode`.

This replaces the path `imread` with the reporter's `np.fromfile` + `imdecode` form. `np.fromfile` opens the path in Python, so Unicode Windows paths work. `IMREAD_COLOR` matches the current `cv2.imread` default (the issue snippet used `IMREAD_UNCHANGED`, which would change PNG-with-alpha).

Empty files keep the old contract: `decoded_image` is None, then the existing `ValueError`. `cv2.imdecode` on a zero-length buffer raises instead of returning None, so this skips `imdecode` when `buf.size == 0`.

No other read paths. No hasher changes.

## Files

1. `perception/hashers/tools.py` (`read()` filesystem branch only)

## Validation

Box run 2026-08-22 11:03 PM AKDT on `/workspace/checkouts/thorn-perception` main `23faec2` (shallow, Linux, Python 3.13.5, `uv sync --all-extras --frozen`). Independent of #43. First apply without the empty-buffer guard failed `test_handling_bad_file_case` (SIFT and AKAZE) with `cv2.error: OpenCV(4.13.0) ... Assertion failed) !buf.empty() in function 'imdecode_'`. Recut then both commands below.

### `make precommit`

```
uv lock --check
Resolved 136 packages in 2ms
uv run ruff check perception tests
All checks passed!
uv run mypy perception
Success: no issues found in 30 source files
uv run black --check . || (echo '\nUnexpected format.' && exit 1)
All done! ✨ 🍰 ✨
38 files would be left unchanged.
uv run pytest tests/
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspace/checkouts/thorn-perception
configfile: pyproject.toml
plugins: cov-7.1.0
collected 59 items

tests/test_approximate_deduplication.py ...                              [  5%]
tests/test_benchmarking.py ......                                        [ 15%]
tests/test_hashers.py ......................                             [ 52%]
tests/test_local_descriptor_deduplication.py ...........                 [ 71%]
tests/test_tmk.py .                                                      [ 72%]
tests/test_tools.py ................                                     [100%]

=============================== warnings summary ===============================
tests/test_benchmarking.py: 5 warnings
tests/test_hashers.py: 5 warnings
  /usr/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=683426) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 59 passed, 10 warnings in 26.46s =======================
```

### `uv run pytest tests/`

```
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspace/checkouts/thorn-perception
configfile: pyproject.toml
plugins: cov-7.1.0
collected 59 items

tests/test_approximate_deduplication.py ...                              [  5%]
tests/test_benchmarking.py ......                                        [ 15%]
tests/test_hashers.py ......................                             [ 52%]
tests/test_local_descriptor_deduplication.py ...........                 [ 71%]
tests/test_tmk.py .                                                      [ 72%]
tests/test_tools.py ................                                     [100%]

=============================== warnings summary ===============================
tests/test_benchmarking.py: 5 warnings
tests/test_hashers.py: 5 warnings
  /usr/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=687427) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 59 passed, 10 warnings in 27.86s =======================
```

## Out of scope

- perception #45 (`compute_parallel` spawn)
- perception #43 (`tmk.py` reshape)
- Switching the whole reader to PIL
- Video `read_video` / ffprobe path encoding
- Rewriting `to_image_array` or the buffer branch

## How to review

One call site. `cv2.imread(` should be gone from `read()`. Latin paths should still decode as RGB via the existing `cvtColor`. Empty files should still raise `ValueError`, not `cv2.error`. I am a volunteer; if you wanted PIL instead of `fromfile`, say so and I will stand down.

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.

If you wanted PIL instead of fromfile, I will stand down.
