### PR TITLE
Stop compute_parallel from relaunching the caller script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug fixes
+
+- VideoHasher `compute_parallel` uses `ThreadPoolExecutor` so spawn workers do not re-import the caller script (#45).
+
 ## [0.9.1] - 2026-05-26
 
 ### Enhancements

--- a/perception/hashers/hasher.py
+++ b/perception/hashers/hasher.py
@@ -141,10 +141,10 @@ class Hasher(ABC):
 
         # We can use a with statement to ensure threads are cleaned up promptly
         records = []
-        if isinstance(self, VideoHasher):
-            executor_class = concurrent.futures.ProcessPoolExecutor
-        else:
-            executor_class = concurrent.futures.ThreadPoolExecutor
+        # ProcessPoolExecutor re-imports the caller's script under spawn
+        # (Windows / macOS). That re-enters compute_parallel and forks
+        # recursively (#45). Threads do not relaunch the parent script.
+        executor_class = concurrent.futures.ThreadPoolExecutor
         with executor_class(max_workers=max_workers) as executor:
             # Start the load operations and mark each future with its filepath
             compute: typing.Callable = (


### PR DESCRIPTION
# Stop compute_parallel from relaunching the caller script

Closes thorn-oss/perception#45.

README Contributing is `make init` then `make precommit`. This PR adds the Unreleased bugfix in `CHANGELOG.md`.

## Checklist

- [x] `make precommit`
- [x] `uv run pytest tests/`

Both passed on this box 2026-08-23 2:02 PM AKDT (59 passed, 5 warnings). Real output is in Validation.

## Summary

`Hasher.compute_parallel` uses `ProcessPoolExecutor` for every `VideoHasher`. Under the spawn start method the worker process re-imports the caller's script. A module-level `compute_parallel` call (the video dedup example) then starts another pool. That is the recursive spawn in #45.

This switches the video path to `ThreadPoolExecutor`, the same executor image hashing already uses. Workers are threads. They do not re-enter the parent script. No new hash algorithms.

ffmpeg / OpenCV / NumPy already release the GIL on the heavy work, so thread workers still overlap.

## Files

1. `perception/hashers/hasher.py` (`compute_parallel` executor choice only)
2. `CHANGELOG.md` (Unreleased bugfix)

## Validation

Run 2026-08-23 2:02 PM AKDT on a local main checkout `23faec2` (Linux, Python 3.13.5). `hasher.py` executor choice only. Docs example left at module level. Independent of #17/#43.

`make precommit` exit 0. `uv run pytest tests/` exit 0. Both 59 passed, 5 warnings (benchmarking fork only; video hasher tests no longer spawn ProcessPool workers).

### `make precommit`

```
uv lock --check
Resolved 136 packages in 6ms
uv run ruff check perception tests
warning: `VIRTUAL_ENV=/workspace/ont-venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
All checks passed!
uv run mypy perception
warning: `VIRTUAL_ENV=/workspace/ont-venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Success: no issues found in 30 source files
uv run black --check . || (echo '\nUnexpected format.' && exit 1)
warning: `VIRTUAL_ENV=/workspace/ont-venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
All done! ✨ 🍰 ✨
38 files would be left unchanged.
uv run pytest tests/
warning: `VIRTUAL_ENV=/workspace/ont-venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspace/checkouts/thorn-perception
configfile: pyproject.toml
plugins: cov-7.1.0
collected 59 items

tests/test_approximate_deduplication.py ...                              [  5%]
tests/test_benchmarking.py ......                                        [ 15%]
tests/test_hashers.py ......................                             [ 52%]
tests/test_local_descriptor_deduplication.py ...........                 [ 71%]
tests/test_tmk.py .                                                      [ 72%]
tests/test_tools.py ................                                     [100%]

=============================== warnings summary ===============================
tests/test_benchmarking.py::test_video_benchmark_dataset
tests/test_benchmarking.py::test_video_benchmark_dataset
tests/test_benchmarking.py::test_video_benchmark_dataset
tests/test_benchmarking.py::test_video_benchmark_dataset
tests/test_benchmarking.py::test_video_benchmark_dataset
  /usr/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=877741) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 59 passed, 5 warnings in 28.68s ========================
```

### `uv run pytest tests/`

```
warning: `VIRTUAL_ENV=/workspace/ont-venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /workspace/checkouts/thorn-perception
configfile: pyproject.toml
plugins: cov-7.1.0
collected 59 items

tests/test_approximate_deduplication.py ...                              [  5%]
tests/test_benchmarking.py ......                                        [ 15%]
tests/test_hashers.py ......................                             [ 52%]
tests/test_local_descriptor_deduplication.py ...........                 [ 71%]
tests/test_tmk.py .                                                      [ 72%]
tests/test_tools.py ................                                     [100%]

=============================== warnings summary ===============================
tests/test_benchmarking.py::test_video_benchmark_dataset
tests/test_benchmarking.py::test_video_benchmark_dataset
tests/test_benchmarking.py::test_video_benchmark_dataset
tests/test_benchmarking.py::test_video_benchmark_dataset
tests/test_benchmarking.py::test_video_benchmark_dataset
  /usr/lib/python3.13/multiprocessing/popen_fork.py:67: DeprecationWarning: This process (pid=880850) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 59 passed, 5 warnings in 28.66s ========================
```

## Out of scope

- perception #17 (Windows `cv2.imread` paths)
- perception #43 (`tmk.py` reshape)
- Wrapping the docs example in `if __name__ == "__main__"`
- New hashers or distance metrics

## Maintainer question

Threads instead of a process pool, or a `__main__` guard?

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.
